### PR TITLE
Change date on Home.

### DIFF
--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -15,7 +15,7 @@
                         <p id="vthacksNum">IV</p>
                     </div>
                     <div id="vthacksDate">
-                        February 12th, 2017
+                        February 17th, 2017
                     </div>
                     <router-link style='text-decoration: none' to='/register'>
                         <v-btn :ripple="{class: 'teal--text'}" class="vt-submit-btn" round>Register</v-btn>


### PR DESCRIPTION
Change the date on the Home page to the real date,
since the home page is still visible to the public.

@Tav0 Can we make this quick little change so sponsors don't get confused if the navigate to the homepage?